### PR TITLE
Fix tests and segfaults

### DIFF
--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -1249,9 +1249,11 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
     } else {
         ngx_file_t file;
 
+        ngx_memzero(&file, sizeof(ngx_file_t));
         file.offset = file.sys_offset = 0;
         file.fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN,
                                 NGX_FILE_DEFAULT_ACCESS);
+        file.log = ctx->log;
 
         /* I don't know if it's a good idea to use the ngx_cycle pool for this,
            but the request is not available here */

--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -387,6 +387,7 @@ ngx_http_fastcgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd,
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->fastcgi.enable = 0;
+    cplcf->conf = &cplcf->fastcgi;
     clcf->handler = ngx_http_fastcgi_cache_purge_handler;
 
     return NGX_CONF_OK;
@@ -673,6 +674,7 @@ ngx_http_proxy_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->proxy.enable = 0;
+    cplcf->conf = &cplcf->proxy;
     clcf->handler = ngx_http_proxy_cache_purge_handler;
 
     return NGX_CONF_OK;
@@ -897,6 +899,7 @@ ngx_http_scgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->scgi.enable = 0;
+    cplcf->conf = &cplcf->scgi;
     clcf->handler = ngx_http_scgi_cache_purge_handler;
 
     return NGX_CONF_OK;
@@ -1144,6 +1147,7 @@ ngx_http_uwsgi_cache_purge_conf(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) 
     clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 
     cplcf->uwsgi.enable = 0;
+    cplcf->conf = &cplcf->uwsgi;
     clcf->handler = ngx_http_uwsgi_cache_purge_handler;
 
     return NGX_CONF_OK;

--- a/t/proxy1.t
+++ b/t/proxy1.t
@@ -92,10 +92,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /purge/proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy1_vars.t
+++ b/t/proxy1_vars.t
@@ -94,10 +94,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /purge/proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy2.t
+++ b/t/proxy2.t
@@ -124,10 +124,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/
@@ -190,10 +190,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config_allowed
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy2_vars.t
+++ b/t/proxy2_vars.t
@@ -127,10 +127,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/
@@ -193,10 +193,10 @@ qr/\[(warn|error|crit|alert|emerg)\]/
 --- config eval: $::config_allowed
 --- request
 PURGE /proxy/passwd
---- error_code: 404
+--- error_code: 412
 --- response_headers
 Content-Type: text/html
---- response_body_like: 404 Not Found
+--- response_body_like: 412 Precondition Failed
 --- timeout: 10
 --- no_error_log eval
 qr/\[(warn|error|crit|alert|emerg)\]/

--- a/t/proxy3.t
+++ b/t/proxy3.t
@@ -25,7 +25,7 @@ our $config = <<'_EOC_';
 
 
     location = /etc/passwd {
-        root               /var/www/html;
+        root               /;
     }
 _EOC_
 

--- a/t/proxy4.t
+++ b/t/proxy4.t
@@ -25,7 +25,7 @@ our $config = <<'_EOC_';
 
 
     location = /etc/passwd {
-        root               /var/www/html;
+        root               /;
     }
 _EOC_
 


### PR DESCRIPTION
There were problems with the tests that were causing invalid failures: several of the tests hadn't been changed to expect 412 status codes rather than 404 status codes (the change introduced in 1449591) and [proxy3.t](https://github.com/nginx-modules/ngx_cache_purge/blob/14495912201a078553bd91143bef070fec278662/t/proxy3.t#L28) and [proxy4.t](https://github.com/nginx-modules/ngx_cache_purge/blob/14495912201a078553bd91143bef070fec278662/t/proxy4.t#L28) had an incorrect `root` directive (unlike the other test files, `root` was `/var/www/html`, but there is no such file as `/var/www/html/etc/passwd`).

After fixing these tests, there were legitimate test failures that were the result of segmentation faults. The second commit fixes a segmentation fault in the implementation of partial key purges (which appears to never have worked) and the third commit fixes the segmentation fault that PR #8 unsuccessfully attempted to fix.