### PR TITLE
Fix race-condition with two parallel PURGE

### DIFF
--- a/ngx_cache_purge_module.c
+++ b/ngx_cache_purge_module.c
@@ -1337,6 +1337,9 @@ ngx_http_purge_file_cache_delete_partial_file(ngx_tree_ctx_t *ctx, ngx_str_t *pa
         file.offset = file.sys_offset = 0;
         file.fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN,
                                 NGX_FILE_DEFAULT_ACCESS);
+        if (file.fd == -1) {
+            return NGX_OK;
+        }
         file.log = ctx->log;
 
         /* I don't know if it's a good idea to use the ngx_cycle pool for this,


### PR DESCRIPTION
If you have many cached pages and you perform 2 PURGEs with `*` together a race-condition will happens while performing `ngx_http_purge_file_cache_delete_partial_file` because the `ngx_open_file` failed.
```
#3  0x0000562d9f6ca0cd in ngx_http_purge_file_cache_delete_partial_file (ctx=0x7ffc18165fa0, path=0x7ffc18165c40) at /tmp/ngx_cache_purge/ngx_cache_purge_module.c:1343
        file = {fd = -1, name = {len = 0, data = 0x0}, info = {st_dev = 0, st_ino = 0, st_nlink = 0, st_mode = 0, st_uid = 0, st_gid = 0, __pad0 = 0, st_rdev = 0, st_size = 0, st_blksize = 0, 
            st_blocks = 0, st_atim = {tv_sec = 0, tv_nsec = 0}, st_mtim = {tv_sec = 0, tv_nsec = 0}, st_ctim = {tv_sec = 0, tv_nsec = 0}, __unused = {0, 0, 0}}, offset = 0, sys_offset = 0, 
          log = 0x562d9f999f08, thread_handler = 0x0, thread_ctx = 0x0, thread_task = 0x0, aio = 0x0, valid_info = 0, directio = 0}
        key_partial = 0x562d9fbf1428 "GEThttpswww.example.com/"
        key_in_file = 0x562d9fd81388 ""
        len = 38
        remove_file = 0
#4  0x0000562d9f59b3fb in ngx_walk_tree (ctx=0x7ffc18165fa0, tree=0x7ffc18165d70) at src/core/ngx_file.c:1061
        data = 0x0
        prev = 0x562d9fbf1428
        p = <optimized out>
        name = 0x562d9fd842db "xxxxxxxxxxxxxxxxxxxxxxxxx"
        len = 32
        rc = <optimized out>
        err = <optimized out>
        file = {len = 58, data = 0x562d9fb93fe0 "/path/to/proxy_cache/8/e3/xxxxxxxxxxxxxxxxxxxxxxxxx"}
        buf = {len = 58, data = 0x562d9fb93fe0 "/path/to/proxy_cache/8/e3/xxxxxxxxxxxxxxxxxxxxxxxxx"}
        dir = {dir = 0x562d9fd84280, de = 0x562d9fd842c8, info = {st_dev = 51, st_ino = 3392243133, st_nlink = 1, st_mode = 33152, st_uid = 65534, st_gid = 65534, __pad0 = 0, st_rdev = 0, 
            st_size = 186262, st_blksize = 4096, st_blocks = 368, st_atim = {tv_sec = 1654360578, tv_nsec = 543368024}, st_mtim = {tv_sec = 1654360578, tv_nsec = 0}, st_ctim = {tv_sec = 1654360578, 
              tv_nsec = 319367272}, __unused = {0, 0, 0}}, type = 0, valid_info = 0}
```

You just need to check if `file.fd == -1` then you don't need to check that file.

Regards